### PR TITLE
Add link to doc with all licenses

### DIFF
--- a/docs/add_content.rst
+++ b/docs/add_content.rst
@@ -144,17 +144,16 @@ To create one or more new topics in a channel, follow these steps.
 Upload files
 ============
 
-   .. tip:: When you create learning resources and materials to upload on Studio and use in Kolibri, make sure to take in consideration diverse learner needs and abilities.
+.. tip:: When you create learning resources and materials to upload on Studio and use in Kolibri, make sure to take in consideration diverse learner needs and abilities.
 
-      Read the :ref:`Best practices for creation of inclusive learning content <a11y_content>` section for guidelines and resources on how to make accessible learning resources.
+   Read the :ref:`Best practices for creation of inclusive learning content <a11y_content>` section for guidelines and resources on how to make accessible learning resources.
 
 
+..  raw:: html
 
-   ..  raw:: html
+    <iframe width="670" height="380" src="https://www.youtube-nocookie.com/embed/28Kk7D9Y3tY?rel=0&modestbranding=1&cc_load_policy=1&iv_load_policy=3" frameborder="0" allow="accelerometer; gyroscope" allowfullscreen></iframe><br /><br />
 
-      <iframe width="670" height="370" src="https://www.youtube.com/embed/28Kk7D9Y3tY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-       Captions for the video are available in English, French and Arabic.
+    Captions for the video are available in English, French and Arabic.      
 
 
 Studio currently supports the upload of the following file formats for individual learning resources:
@@ -205,7 +204,7 @@ To upload individual learning resources into your channel, follow these steps.
 
          Add metadata to files.
 
-   .. warning:: Remember to select the `appropriate license <https://creativecommons.org/choose/>`_ in case you are adding files to a channel that you plan to release publicly. 
+   .. warning:: Remember to select the `appropriate license <https://learningequality.org/r/kolibri-licenses>`_ in case you are adding files to a channel that you plan to release publicly. 
       
       You can select a **Special Permissions** license and customize the description, in cases where the available licenses do not match the resources permissions.
 
@@ -267,9 +266,9 @@ Create exercises
 
 Captions for the video are available in English, French and Arabic.
 
-   ..  raw:: html
+..  raw:: html
 
-       <iframe width="670" height="370" src="https://www.youtube.com/embed/59j8la43Ow4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="670" height="380" src="https://www.youtube-nocookie.com/embed/59j8la43Ow4?rel=0&modestbranding=1&cc_load_policy=1&iv_load_policy=3" frameborder="0" allow="accelerometer; gyroscope" allowfullscreen></iframe><br /><br />
 
 
 In Kolibri you can create exercises that contain a set of interactive questions (numeric, multiple choice, check all that apply, or true or false) that learners can engage with. With exercises, learners will receive instant feedback on whether they answer each question correctly or incorrectly. For each exercise you can set the mastery criteria, and Kolibri will cycle through the available questions in an exercise until learners achieve mastery. It is also possible to set the question/answer/hint order, indicate whether to randomize the order of questions/answers, and add images and formulas to questions, answers, and hints.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,14 +15,14 @@ While it is possible to install **Kolibri** and import channels without an activ
       Kolibri and Kolibri Studio content pipeline.
 
 
-Introduction to Kolibri Studio (video)
-======================================
+**Introduction to Kolibri Studio (video)**
 
-   ..  raw:: html
+..  raw:: html
 
-       <iframe width="670" height="370" src="https://www.youtube.com/embed/CCswYsMFn1I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="670" height="380" src="https://www.youtube-nocookie.com/embed/CCswYsMFn1I?rel=0&modestbranding=1&cc_load_policy=1&iv_load_policy=3" frameborder="0" allow="accelerometer; gyroscope" allowfullscreen></iframe><br /><br />
 
-       Captions for the video are available in English, French and Arabic.
+    Captions for the video are available in English, French and Arabic.      
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/working_channels.rst
+++ b/docs/working_channels.rst
@@ -24,14 +24,13 @@ When you login to Kolibri Studio, you will be able to see Kolibri channels organ
 .. tip:: To return to the **My channels** page from any location in Studio, click the |menu| (menu) button to open the sidebar and select |channels| **Channels**.
 
 
-Managing Kolibri Content Library (video)
-========================================
+**Manage Kolibri Content Library (video)**
 
-Captions for the video are available in English, French and Arabic.
+..  raw:: html
 
-   ..  raw:: html
+    <iframe width="670" height="380" src="https://www.youtube-nocookie.com/embed/elsJep_IhNs?rel=0&modestbranding=1&cc_load_policy=1&iv_load_policy=3" frameborder="0" allow="accelerometer; gyroscope" allowfullscreen></iframe><br /><br />
 
-       <iframe width="670" height="370" src="https://www.youtube.com/embed/elsJep_IhNs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+Captions for the video are available in English, French and Arabic.      
 
 
 


### PR DESCRIPTION
Not all of our licenses are CC, and now we are linking to https://learningequality.org/r/kolibri-licenses

Plus I sneaked some adjusted formatting for iframes with YT videos.