### PR TITLE
fixing bullets and updating readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,10 @@
 Studio Docs
 ===========
 
-.. image:: https://api.travis-ci.org/learningequality/studio-docs.svg?branch=master
-  :target: https://travis-ci.com/github/learningequality/studio-docs
-.. image:: https://img.shields.io/badge/docs-user-ff69b4.svg
-  :target: http://kolibri-studio.readthedocs.org/en/latest/
-.. image:: https://img.shields.io/badge/support-on%20discourse-blue.svg
-  :target: https://community.learningequality.org/
-.. image:: https://img.shields.io/badge/demo-online-green.svg
-  :target: http://studio.learningequality.org/
-
-
 What is this?
 -------------
 
-This is the user documentation repository of Kolibri Studio, where documentation is maintained. The docs themselves are hosted at `kolibri-studio.readthedocs.io <https://kolibri-studio.readthedocs.io/>`__.
+This is the repository where user documentation for `Kolibri Studio <https://studio.learningequality.org/>`__ is maintained. To read the documentation visit `kolibri-studio.readthedocs.io <https://kolibri-studio.readthedocs.io/>`__.
 
 
 Building the docs locally

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-# These are for building the docs
 sphinx==2.4.4
-sphinx_rtd_theme
-#sphinx-intl
-divio-docs-theme
-sphinx-autobuild
-sphinx-version-warning
-sphinx-notfound-page
+sphinx-rtd-theme==0.5.2
+#sphinx-intl==2.0.1
+divio-docs-theme==0.0.22
+sphinx-autobuild==0.7.1
+sphinx-version-warning==1.1.2 
+sphinx-notfound-page==0.6


### PR DESCRIPTION

* Tries to fix bulleted lists using strategy from https://github.com/learningequality/kolibri/pull/8002/files (fixes https://github.com/learningequality/studio-docs/issues/24)
* Pins other unpinned dependencies to current most recent versions
* Removes outdated badges and updates readme text slightly


