### PR TITLE
Add the ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+  - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,4 @@ sphinx:
 python:
   install:
   - requirements: requirements.txt
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,4 +9,3 @@ sphinx:
 python:
   install:
   - requirements: requirements.txt
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ import sys
 # sys.path.insert(0, os.path.abspath('.'))
 from datetime import datetime
 
+import sphinx_rtd_theme
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 
@@ -89,40 +90,15 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
+# html_theme = 'default'
 
-html_theme = 'default'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:
     os.system("sphinx-apidoc --doc-project='Python Reference' -f -o . ../kolibri ../kolibri/test ../kolibri/deployment/ ../kolibri/dist/")
-
-# Trying out Divio theme https://github.com/divio/divio-docs-theme/
-
-#if not on_rtd:  # only import and set the theme if we're building docs locally
-#    import divio_docs_theme
-#    html_theme = 'divio_docs_theme'
-#    html_theme_path = ['.', divio_docs_theme.get_html_theme_path()]
-#    html_theme_options = {
-#        'display_version': False,
-#        'prev_next_buttons_location': 'both',
-#        'style_external_links': True,
-#        'show_cloud_banner': False,
-    #        'cloud_banner_markup': """
-    #            <div class="divio-cloud">
-    #                <span class="divio-cloud-caption">Cloud deployment by Divio</span>
-    #                <iframe src="https://player.vimeo.com/video/435660924" width="226" height="141" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
-    #                <p>There's a better, faster, easier way to develop, deploy and manage web applications.</p>
-    #                <a class="btn-neutral divio-cloud-btn" target="_blank" href="https://www.divio.com">Find out more at Divio</a>
-    #            </div>
-    #        """,
-#    }
-
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = ['.', sphinx_rtd_theme.get_html_theme_path()]
+ 
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = ['.', sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary

Starting on September 25, ReadTheDocs builds without configuration file won't work anymore. This adds the configuration file.

## References

https://blog.readthedocs.com/migrate-configuration-v2/

## Reviewer guidance

- Preview the configuration file
- Preview the ReadTheDocs build of Studio user docs TODO